### PR TITLE
Use Omnivore API key instead of cookie

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,15 +20,12 @@ A little script that I made to import my huge collection of links from [Instapap
 
    **⚠️ The filename must be `instapaper-export.csv`**
 
-3. Go to https://omnivore.app, login, and copy the value of the **auth cookie**. How to do this differs for every browser I guess, but if you're using Chrome:
 
-   - Open **Developer Tools** (Option + Cmd + I)
-   - Go the **Application** tab
-   - Find the **auth** cookie in the list. Copy the value. It should look something like this: `eyJhbGciOiJIUzI1NiI ...`
+3. [Create an API key in Omnivore](https://omnivore.app/settings/api) and copy the value.
 
-4. Add the auth cookie value to the `.env` file:
+4. Add the API key to the `.env` file:
    ```
-   OMNIVORE_AUTH_COOKIE=eyJhbGciOiJIUzI1NiI ...
+   OMNIVORE_API_KEY=1d45ae09-789f-...
    ```
 5. Run the script. It might take a few minutes.
    ```

--- a/index.ts
+++ b/index.ts
@@ -77,15 +77,15 @@ async function processCsv() {
 }
 
 async function main() {
-  if (!process.env.OMNIVORE_AUTH_COOKIE) {
+  if (!process.env.OMNIVORE_API_KEY) {
     throw new Error(
-      "No auth token found. Did you forget to add it to the .env file?"
+      "No API key found. Did you forget to add it to the .env file?"
     );
   }
 
   const client = new GraphQLClient(OMNIVORE_API_URL, {
     headers: {
-      Cookie: `auth=${process.env.OMNIVORE_AUTH_COOKIE};`,
+      authorization: process.env.OMNIVORE_API_KEY,
     },
   });
 


### PR DESCRIPTION
First of all, thanks for writing this script! I used it as a starting point for [a script to import from Pocket's permanent library](https://github.com/iangreenleaf/pocket-to-omnivore-import), and it was super helpful to have an example to follow.

I noticed that you're using an auth cookie from Omnivore, but (at least now) they offer API tokens that are easier to acquire and probably also the more official way to do this. I switched to this in my script and it works great. I couldn't test this PR because I don't have an Instapaper account, but I'm guessing it should work fine for you too.